### PR TITLE
Adding usage of end user

### DIFF
--- a/styleguide/a-z-word-list-term-collections/e/end user
+++ b/styleguide/a-z-word-list-term-collections/e/end user
@@ -1,0 +1,6 @@
+end user
+
+write as two seperate words. Don't hyphen as end-user.
+
+Example:
+An end user tested and provided feedback to the UI.


### PR DESCRIPTION
I have observed several variations for 'end user' in use. As for example, enduser, end-user, end user. This PR provides the correct way to use 'end user' in the documentation.